### PR TITLE
Alter table wrapping for wide tables

### DIFF
--- a/misc/cyverse_sphinx_conf.py
+++ b/misc/cyverse_sphinx_conf.py
@@ -21,8 +21,10 @@ source_parsers = {
 }
 source_suffix = ['.md', '.rst']
 
+common_static_path = os.path.join(os.path.dirname(__file__), 'static')
+
 templates_path = ['_templates']
-html_static_path = ['_static']
+html_static_path = ['_static', common_static_path]
 exclude_patterns = ['_build']
 master_doc = 'index'
 pygments_style = 'sphinx'
@@ -68,3 +70,4 @@ def setup(app):
         True
     )
     app.add_transform(AutoStructify)
+    app.add_stylesheet('cyverse.css')

--- a/misc/static/cyverse.css
+++ b/misc/static/cyverse.css
@@ -1,0 +1,5 @@
+/* Table wrapping */
+.wy-table-responsive table td,
+.wy-table-responsive table th {
+    white-space: normal !important;
+}


### PR DESCRIPTION
This changes how cells wrap long text, and instead shrinks the table
horizontally to fit without the view space. The next step might be to extend the
width of the view space to allow for wider tables that don't wrap inner content
as aggressively.